### PR TITLE
Improved compatibility, new configs, and balance tweaks

### DIFF
--- a/InstanceLootPlugin/DropRateManager.cs
+++ b/InstanceLootPlugin/DropRateManager.cs
@@ -1,0 +1,77 @@
+using System;
+using BepInEx.Configuration;
+
+namespace InstanceLootPlugin;
+
+public class DropRateManager
+{
+    private ConfigEntry<bool> EnableBadLuckProtection;
+    private ConfigEntry<bool> EnableSwarmsScaling;
+    private ConfigEntry<float> DropChanceMultiplier;
+    private ConfigEntry<float> BaseDropChance;
+    private ConfigEntry<float> MinimumDropChance;
+
+    public DropRateManager(
+        ConfigEntry<bool> enableBadLuckProtection,
+        ConfigEntry<bool> enableSwarmsScaling,
+        ConfigEntry<float> dropChanceMultiplier,
+        ConfigEntry<float> baseDropChance,
+        ConfigEntry<float> minimumDropChance)
+    {
+        EnableBadLuckProtection = enableBadLuckProtection;
+        EnableSwarmsScaling = enableSwarmsScaling;
+        DropChanceMultiplier = dropChanceMultiplier;
+        BaseDropChance = baseDropChance;
+        MinimumDropChance = minimumDropChance;
+    }
+
+    public float GetPlayerAwareBaseDropChance(int playerCount, float dropChance)
+    {
+        float playerBasedDropRateMultiplier = 1f / playerCount;
+        float multiplier = playerBasedDropRateMultiplier * DropChanceMultiplier.Value;
+        float newDropChance = Math.Max(BaseDropChance.Value * multiplier, MinimumDropChance.Value);
+
+        if (!dropChance.Equals(newDropChance))
+        {
+            dropChance = newDropChance;
+            Log.Debug(
+                $"Using dropRate of {dropChance}% (base={BaseDropChance.Value}, multiplier={DropChanceMultiplier.Value}, playerCount={playerCount}, minimumDropChance={MinimumDropChance.Value}");
+        }
+
+        return dropChance;
+    }
+
+    public float ComputeDropChance(bool isSwarmEnabled, float nativeDropChance, float nativeBaseDropChance, float dropChance)
+    {
+        // Approximately balance Swarms Artifact since they didn't do a good job of it.
+        float swarmModifiedNativeChance = !(EnableSwarmsScaling.Value && isSwarmEnabled) || nativeDropChance == 0
+            ? nativeDropChance
+            : (nativeDropChance - nativeBaseDropChance) * 0.6f + nativeBaseDropChance;
+
+        // Apply the multipliers used by the game to respect the many drop rate factors.
+        float baseModifier = nativeBaseDropChance / 5f;
+        float enemyModifier = swarmModifiedNativeChance / nativeBaseDropChance;
+
+        return dropChance * baseModifier * enemyModifier;
+    }
+
+    public bool NeedsBadLuckProtection(float actualDropChance, float time)
+    {
+        if (EnableBadLuckProtection.Value && DropRateTracker.cumulativeDropChance >= 100 && actualDropChance > 0)
+        {
+            var behindOnDrops = DropRateTracker.expectedItems > DropRateTracker.totalItemDrops;
+            var itemsPerMinute = DropRateTracker.totalItemDrops / (time / 60);
+            return behindOnDrops || itemsPerMinute < 0.8;
+        }
+
+        return false;
+    }
+
+    public float GetBadLuckProtectedDropChance(float dropChance)
+    {
+        float badLuckBoost = DropRateTracker.cumulativeDropChance - 100;
+        float totalDropChance = Math.Min(dropChance + badLuckBoost, 90);
+        Log.Debug($"Bad Luck Protection triggered! ({dropChance}% => {totalDropChance}%)");
+        return totalDropChance;
+    }
+}

--- a/InstanceLootPlugin/DropRateTracker.cs
+++ b/InstanceLootPlugin/DropRateTracker.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RoR2;
+
+namespace InstanceLootPlugin;
+
+public static class DropRateTracker
+{
+    public static long totalItemDrops { get; private set; } = 0;
+    public static float cumulativeDropChance { get; private set; } = 0;
+    public static float expectedItems { get; private set; } = 0;
+
+    private static Dictionary<float, long> DropRateReport = new Dictionary<float, long>();
+
+    public static void ResetTracker()
+    {
+        DropRateReport = new Dictionary<float, long>();
+        totalItemDrops = 0;
+        cumulativeDropChance = 0;
+        expectedItems = 0;
+    }
+
+    public static void RegisterDropOpportunity(float dropChance)
+    {
+        cumulativeDropChance += dropChance;
+        expectedItems += (float)Math.Round(dropChance / 100, 2);
+
+        long value;
+        if (DropRateReport.TryGetValue(dropChance, out value))
+        {
+            DropRateReport[dropChance] += 1;
+        }
+        else
+        {
+            DropRateReport.Add(dropChance, 1);
+        }
+    }
+
+    public static void RegisterItemDrop(GenericPickupController.CreatePickupInfo createPickupInfo)
+    {
+        // It is worth noting that there is a bug with this logic
+        // - If cumulativeDropChance > 100
+        //   AND players are falling behind on loot
+        //   AND many flying enemies were killed at the same time
+        // - The drop rate of those enemies will be calculated _before_ the "dropletHitGround" event fires, because the droplet takes time to fall to the ground.
+        // - This can cause bad luck protection to trigger multiple item drops at once
+        if (createPickupInfo.pickupIndex.pickupDef is not null)
+        {
+            var def = createPickupInfo.pickupIndex.pickupDef;
+            bool isItem = def.coinValue == 0 && def.nameToken != "PICKUP_LUNAR_COIN";
+            if (isItem)
+            {
+                cumulativeDropChance = 0;
+                totalItemDrops += 1;
+            }
+        }
+    }
+
+    public static void LogReport()
+    {
+        if (Run.instance is not null && Run.instance.isActiveAndEnabled)
+        {
+            var totalKills = DropRateReport.Values.Aggregate(0L, ((i, l) => i + l));
+            if (totalKills == 0)
+                return;
+
+            var dropRateBreakdown = DropRateReport.Keys
+                .OrderByDescending(f => f)
+                .Aggregate("Kills by Drop Rate", (s, f) => $"{s}\n  {f}%: {DropRateReport[f]} kills");
+
+            var timer = Run.instance.GetRunStopwatch();
+            var minutes = timer / 60;
+            var averageDropRate = DropRateReport.Keys.Aggregate(0f,
+                (f, f1) => f + (DropRateReport[f1] * f1)) / totalKills;
+
+            string report = "------ DROP RATE RUN REPORT -----\n";
+            report += $"Stage: {Run.instance.stageClearCount + 1}\n";
+            report += $"Run Duration: {timer}s\n";
+            report += $"Total kills: {totalKills}\n";
+            report += $"Total items: {totalItemDrops}\n";
+            report += $"Theoretical Average Drop Rate: {averageDropRate}%\n";
+            report += $"Actual Average Drop Rate: {((float)totalItemDrops / (float)totalKills) * 100}%\n";
+            report += $"Drops per Minute: {Math.Round(totalItemDrops / minutes, 2)}\n";
+            report += dropRateBreakdown + "\n";
+            report += "------ END OF REPORT -----";
+            Log.Info(report);
+        }
+    }
+}

--- a/InstanceLootPlugin/InstanceLootPlugin.cs
+++ b/InstanceLootPlugin/InstanceLootPlugin.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Linq;
 using BepInEx;
+using BepInEx.Configuration;
 using R2API;
 using R2API.Networking.Interfaces;
 using RoR2;
@@ -6,6 +9,7 @@ using RoR2.UI;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.Networking;
+using UnityEngine.SceneManagement;
 using static HG.Reflection.SearchableAttribute;
 
 [assembly: OptIn]
@@ -14,84 +18,255 @@ using static HG.Reflection.SearchableAttribute;
 namespace InstanceLootPlugin
 {
     /// <summary>
-    /// This plugin is used to provide instance based loot when you're running with "Artifact of Sacrifice" and "Artifact of Command" enabled. 
-    /// The way it works is when a monster dies it would normally drop a CommandCube gameobject which is a network object. 
+    /// This plugin is used to provide instance based loot when you're running with "Artifact of Sacrifice" and "Artifact of Command" enabled.
+    /// The way it works is when a monster dies it would normally drop a CommandCube gameobject which is a network object.
     /// On interaction it spawns an item.
-    /// 
+    ///
     /// This mod overrides that behavior. Instead of spawning a network CommandCube on drop. We hook OnDropletHitGroundServer.
-    /// The hook sends a network message to all clients and tells each client to spawn a commandcube gameobject locally. 
-    /// 
+    /// The hook sends a network message to all clients and tells each client to spawn a commandcube gameobject locally.
+    ///
     /// Since object is local no one but the local client can see it and interact. Since it isn't a real network object we need
     /// to also hook some of the interaction actions around it as otherwise you'll fail to interact since the default logic expects
-    /// a network object which the server doesn't know about. 
-    /// 
+    /// a network object which the server doesn't know about.
+    ///
     /// Once an item is selected a game object for that item type is spawned, this one is spawned on the server by sending a message \
     /// to the server to run the logic to spawn. If we just tried to spawn locally we could get errors on clients as they are not allowed to spawn
-    /// network objects, thus the message to the server. Since the item is spawned on the server it can be picked up now by anyone but assuming that's ok 
+    /// network objects, thus the message to the server. Since the item is spawned on the server it can be picked up now by anyone but assuming that's ok
     /// since the item spawns in front of the character interacting anyway.
-    /// 
+    ///
     /// 2 other features provided by the plugin
     /// 1) Press F3 will pull all CommandCube objects to you in a circle, so any objects you might have missed aren't lost
     /// 2) A console command `drop_rate <value>` which you can use to set the drop rate of items from monsters
     /// </summary>
     [BepInDependency(ItemAPI.PluginGUID)]
+    [BepInDependency("com.bepis.r2api")]
     [BepInDependency(LanguageAPI.PluginGUID)]
     [BepInPlugin(PluginGUID, PluginName, PluginVersion)]
     public class InstanceLootPlugin : BaseUnityPlugin
     {
         // The Plugin GUID should be a unique ID for this plugin,
         // which is human readable (as it is used in places like the config).
-        // If we see this PluginGUID as it is on thunderstore,
-        // we will deprecate this mod.
-        // Change the PluginAuthor and the PluginName !
         public const string PluginGUID = PluginAuthor + "." + PluginName;
         public const string PluginAuthor = "programit";
         public const string PluginName = "InstanceBasedLoot";
-        public const string PluginVersion = "1.0.0";
+        public const string PluginVersion = "2.0.0";
+        private static ConfigEntry<float> DropChanceMultiplier { get; set; }
+        private static ConfigEntry<float> MinimumDropChance { get; set; }
+        private static ConfigEntry<float> BaseDropChance { get; set; }
+        private static ConfigEntry<bool> EnablePlayerDropRateScaling { get; set; }
+        private static ConfigEntry<bool> EnableSwarmsScaling { get; set; }
+        private static ConfigEntry<bool> EnableBadLuckProtection { get; set; }
+
+        // Matches current default drop rate. Differs from BaseDropChance because we override it for player scaling.
+        public static float dropChance = 5;
+
+        // Internal state indicating whether or not the mod hooks have been registered or not.
+        private static bool IsModHooked = false;
+
+        // We will occasionally remove the hooks and not allow them to be readded.
+        // We do this because there is an artifact key that spawns when you load into bulwark's ambry.
+        // This is significant because this mod is incompatible with non-commandcube pickups.
+        // Leaving the mod active causes an NRE in "artifact trial" code, which results in artifacts not being
+        // awarded for successful clears.
+        // To work around this, we simply unhook the mod for artifact world.
+        private bool forceDisabled = false;
+
+        // Persist drop rates that have been manually set via the console. Resets between runs.
+        private static bool useManualDropRate = false;
+
+        private static DropRateManager dropRateManager;
 
         public void Awake()
         {
             Log.Init(Logger);
-        }
 
-        // Matches current default drop rate
-        public static float dropChance = 5;
+            // Read configs from file
+            DropChanceMultiplier = base.Config.Bind<float>(
+                "General",
+                "DropChanceMultiplier",
+                1f,
+                "Manipulate drop rate. Use `0.5` to halve or `2` to double."
+            );
+
+            MinimumDropChance = base.Config.Bind<float>(
+                "General", "MinimumDropChance",
+                1f,
+                "The lowest possible drop chance when player count scaling is active."
+            );
+
+            EnablePlayerDropRateScaling = base.Config.Bind<bool>(
+                "General",
+                "EnablePlayerBasedDropRateScaling",
+                true,
+                "Enabling this will reduce drop rates to account for shared loot."
+            );
+
+            EnableSwarmsScaling = base.Config.Bind<bool>(
+                "General",
+                "EnableSwarmsScaling",
+                true,
+                "Enabling this will (correctly) reduce drop rates for Artifact of Swarms."
+            );
+
+            EnableBadLuckProtection = base.Config.Bind<bool>(
+                "General",
+                "EnableBadLuckProtection",
+                true,
+                "Enabling this will increase drop rate consistency with low drop rates."
+            );
+
+            BaseDropChance = base.Config.Bind<float>(
+                "General",
+                "BaseDropChance",
+                5f,
+                "Base item drop chance. It is recommended to leave this at the default value."
+            );
+            dropChance = BaseDropChance.Value;
+
+            dropRateManager = new DropRateManager(
+                EnableBadLuckProtection,
+                EnableSwarmsScaling,
+                DropChanceMultiplier,
+                BaseDropChance,
+                MinimumDropChance);
+        }
 
         private void Update()
         {
-            // Pulls all items on map to you. 
-            if (Input.GetKeyDown(KeyCode.F3))
+            // Pulls all items on map to you.
+            if (Input.GetKeyDown(KeyCode.F3) && IsModHooked)
             {
-                GenericPickupController.FindObjectsOfType<RuleBookViewer>();
-                var items = GenericPickupController.FindObjectsOfType<PickupDisplay>();
-                var playerPos = ((MPEventSystem)EventSystem.current).localUser.cachedMaster.GetBodyObject().transform.position;
-                float radius = 10f;
-                for (int i = 0; i < items.Length; i++)
+                try
                 {
-                    var obj = items[i];
-
-                    if (!obj.highlight.name.StartsWith("CommandCube"))
+                    GenericPickupController.FindObjectsOfType<RuleBookViewer>();
+                    var items = GenericPickupController.FindObjectsOfType<PickupDisplay>();
+                    var playerPos = ((MPEventSystem)EventSystem.current).localUser.cachedMaster.GetBodyObject()
+                        .transform.position;
+                    float radius = 10f;
+                    for (int i = 0; i < items.Length; i++)
                     {
-                        continue;
+                        var obj = items[i];
+
+                        if (!obj.highlight.name.StartsWith("CommandCube"))
+                        {
+                            continue;
+                        }
+
+                        float angle = i * Mathf.PI * 2f / items.Length;
+                        Vector3 newPos = new Vector3(playerPos.x + Mathf.Cos(angle) * radius, playerPos.y,
+                            playerPos.z + Mathf.Sin(angle) * radius);
+
+                        obj.gameObject.transform.position = newPos;
                     }
-
-                    float angle = i * Mathf.PI * 2f / items.Length;
-                    Vector3 newPos = new Vector3(playerPos.x + Mathf.Cos(angle) * radius, playerPos.y, playerPos.z + Mathf.Sin(angle) * radius);
-
-                    obj.gameObject.transform.position = newPos;
+                }
+                catch (NullReferenceException e)
+                {
+                    Logger.LogDebug("Failed to pull CommandCubes with F3 - most likely because there were none.");
                 }
             }
         }
 
+        // This is largely a workaround to provide a workaround for drops not being interactable when a player joins
+        // a lobby with "DropInMultiplier" after the activeSceneChanged event has fired.
+        // This cause of this issue is that the hooks have not been loaded, so this serves as a simple way for users to
+        // trigger a hook load.
+        // If they don't trigger this event, starting the next stage will fix it for them automatically.
+        private void OnApplicationFocus(bool hasFocus)
+        {
+            if (hasFocus)
+            {
+                ReevaluateLifecycle();
+            }
+        }
+
         private void OnEnable()
-        {            
+        {
+
+            // This event is called:
+            // - after the boss dies in teleporter events
+            // - the end of each stage of the Voidling and Mithrix fights
+            // - after the Gilded Coast and A Moment Whole encounters
+            //
+            // It considers player count, Shrine of the Mountain activations, boss item drop chance, and other factors
+            // and then spawns the necessary items
+            On.RoR2.BossGroup.DropRewards += (orig, self) =>
+            {
+                if (EnablePlayerDropRateScaling.Value && IsModHooked)
+                {
+                    self.scaleRewardsByPlayerCount = false;
+                }
+
+                orig.Invoke(self);
+            };
+
+            // Handles the general state of the mod
+            SceneManager.activeSceneChanged += (oldScene, newScene) =>
+            {
+                bool isMenuScene = newScene.name == "loadingbasic"
+                                   || newScene.name == "intro"
+                                   || newScene.name == "splash"
+                                   || newScene.name == "title"
+                                   || newScene.name == "eclipseworld" // Eclipse menu
+                                   || newScene.name == "infinitetowerworld" // Simulacrum menu
+                                   || newScene.name == "lobby";
+
+                // Maintains disabled state so that tabbing into the game can't re-hook in Bulwark's Ambry.
+                forceDisabled = newScene.name == "artifactworld" || isMenuScene;
+
+                // Reset manual drop rates and drop rate tracking between runs
+                if (isMenuScene)
+                {
+                    useManualDropRate = false;
+                    DropRateTracker.ResetTracker();
+                }
+
+                // Update drop rate and (un)hook if necessary
+                ReevaluateLifecycle();
+            };
+
+            // Register message which we use to spawn the item itself
+            R2API.Networking.NetworkingAPI.RegisterMessageType<SpawnCustomMessage2>();
+        }
+
+
+        private void ReevaluateLifecycle()
+        {
+            // We recalculate drop rate each stage to account for any new or missing players
+            if (EnablePlayerDropRateScaling.Value && IsSacrificeEnabled() && !useManualDropRate)
+                dropChance = dropRateManager.GetPlayerAwareBaseDropChance(GetPlayerCount(), dropChance);
+
+            if (forceDisabled)
+            {
+                if (IsModHooked)
+                {
+                    Log.Warning("Force Disabled: Will remove hooks, even if Artifact of Command is enabled.");
+                    UnHook();
+                }
+                else
+                {
+                    Log.Debug("Force Disabled: Will not hook.");
+                }
+                return;
+            }
+
+            bool commandEnabled = IsCommandEnabled();
+            if (IsModHooked && !commandEnabled)
+                UnHook();
+            else if (!IsModHooked && commandEnabled)
+                Hook();
+        }
+
+        private void Hook()
+        {
+            Logger.LogInfo("Loading hooks");
+
             // Sets drop chance
             On.RoR2.Util.GetExpAdjustedDropChancePercent += Util_GetExpAdjustedDropChancePercent;
 
             //// Hooks network handler for setup
             On.RoR2.Networking.NetworkMessageHandlerAttribute.RegisterClientMessages += NetworkMessageHandlerAttribute_RegisterClientMessages;
 
-            // Hooks pickup creation to control drop on client 
+            // Hooks pickup creation to control drop on client
             On.RoR2.Artifacts.CommandArtifactManager.OnDropletHitGroundServer += CommandArtifactManager_OnDropletHitGroundServer;
 
             // Hook interaction since we didn't generate a real network object
@@ -100,11 +275,24 @@ namespace InstanceLootPlugin
             // Override the choice again since this isn't a real network object we'd have issue.
             On.RoR2.PickupPickerController.SubmitChoice += PickupPickerController_SubmitChoice;
 
-            // Register message which we use to spawn the item itself
-            R2API.Networking.NetworkingAPI.RegisterMessageType<SpawnCustomMessage2>();
-
             // Ignore since we'll create ourselves
             On.RoR2.GenericPickupController.CreatePickup += GenericPickupController_CreatePickup;
+
+            IsModHooked = true;
+        }
+
+        private void UnHook()
+        {
+            Logger.LogInfo("Unloading hooks");
+
+            On.RoR2.Util.GetExpAdjustedDropChancePercent -= Util_GetExpAdjustedDropChancePercent;
+            On.RoR2.Networking.NetworkMessageHandlerAttribute.RegisterClientMessages -= NetworkMessageHandlerAttribute_RegisterClientMessages;
+            On.RoR2.Artifacts.CommandArtifactManager.OnDropletHitGroundServer -= CommandArtifactManager_OnDropletHitGroundServer;
+            On.RoR2.Interactor.AttemptInteraction -= Interactor_AttemptInteraction;
+            On.RoR2.PickupPickerController.SubmitChoice -= PickupPickerController_SubmitChoice;
+            On.RoR2.GenericPickupController.CreatePickup -= GenericPickupController_CreatePickup;
+
+            IsModHooked = false;
         }
 
         private GenericPickupController GenericPickupController_CreatePickup(On.RoR2.GenericPickupController.orig_CreatePickup orig, ref GenericPickupController.CreatePickupInfo createPickupInfo)
@@ -118,17 +306,20 @@ namespace InstanceLootPlugin
             {
                 return;
             }
+
             ref PickupPickerController.Option ptr = ref self.options[choiceIndex];
             if (!ptr.available)
             {
                 return;
             }
+
             PickupPickerController.PickupIndexUnityEvent pickupIndexUnityEvent = self.onPickupSelected;
             if (pickupIndexUnityEvent == null)
             {
                 return;
             }
-            pickupIndexUnityEvent.Invoke(ptr.pickupIndex.value);    // This spawns an isntance of the item when client==server
+
+            pickupIndexUnityEvent.Invoke(ptr.pickupIndex.value); // This spawns an instance of the item when client==server
             Log.Info($"Sending CreatePickup {self.options[choiceIndex].pickupIndex}");
 
             new SpawnCustomMessage2(self.options[choiceIndex].pickupIndex, ((MPEventSystem)EventSystem.current).localUser.cachedMaster.GetBodyObject().transform.position)
@@ -155,6 +346,8 @@ namespace InstanceLootPlugin
 
         private void CommandArtifactManager_OnDropletHitGroundServer(On.RoR2.Artifacts.CommandArtifactManager.orig_OnDropletHitGroundServer orig, ref GenericPickupController.CreatePickupInfo createPickupInfo, ref bool shouldSpawn)
         {
+            DropRateTracker.RegisterItemDrop(createPickupInfo);
+
             NetworkServer.SendToAll(969, new SpawnCustomMessage() { position = createPickupInfo.position, pickupIndex = createPickupInfo.pickupIndex });
             shouldSpawn = false;
         }
@@ -169,17 +362,73 @@ namespace InstanceLootPlugin
         }
 
         /// <summary>
-        /// Sets drop rate 
+        /// Sets drop rate
         /// </summary>
-        private static float Util_GetExpAdjustedDropChancePercent(On.RoR2.Util.orig_GetExpAdjustedDropChancePercent orig, float baseChancePercent, UnityEngine.GameObject characterBodyObject)
+        private static float Util_GetExpAdjustedDropChancePercent(
+            On.RoR2.Util.orig_GetExpAdjustedDropChancePercent orig,
+            float nativeBaseDropChance, UnityEngine.GameObject characterBodyObject)
         {
-            return dropChance;
+            // Drop chance depends on a number of factors.
+            // These factors include enemy elite level, teleporter event activity, and Artifact of Swarms enablement.
+            // There are also entities with a drop chance of 0%, such as the "HealingAffix" spawned by slain mending elites
+            // For more details on drop rates read https://riskofrain2.fandom.com/wiki/Artifacts#Sacrifice
+            float nativeDropChance = orig.Invoke(nativeBaseDropChance, characterBodyObject);
+
+            // Perform custom drop chance logic
+            float finalDropChance = dropRateManager.ComputeDropChance(IsSwarmEnabled(), nativeDropChance, nativeBaseDropChance, dropChance);
+            Log.Debug($"DropChance: original_base={nativeBaseDropChance} original_final={nativeDropChance}; plugin_base={dropChance}; plugin_final={finalDropChance} (Character={characterBodyObject.name})");
+
+            DropRateTracker.RegisterDropOpportunity(finalDropChance);
+
+            // Perform Bad Luck Protection, if necessary
+            if (dropRateManager.NeedsBadLuckProtection(finalDropChance, Run.instance.GetRunStopwatch()))
+            {
+                return dropRateManager.GetBadLuckProtectedDropChance(finalDropChance);
+            }
+
+            return finalDropChance;
         }
 
         [ConCommand(commandName = "drop_rate", flags = ConVarFlags.ExecuteOnServer, helpText = "Sets Drop rate for items")]
         private static void CCSetDropRate(ConCommandArgs args)
         {
             dropChance = args.GetArgFloat(0);
+            useManualDropRate = true;
+        }
+
+        [ConCommand(commandName = "drop_rate_report", flags = ConVarFlags.ExecuteOnServer, helpText = "View Drop Rate Report")]
+        private static void CCGetDropRateReport(ConCommandArgs args)
+        {
+            if (IsModHooked)
+            {
+                DropRateTracker.LogReport();
+            }
+        }
+
+        private static bool IsSacrificeEnabled()
+        {
+            return RunArtifactManager.instance is not null
+                   && RunArtifactManager.instance.isActiveAndEnabled
+                   && RunArtifactManager.instance.IsArtifactEnabled(RoR2Content.Artifacts.sacrificeArtifactDef);
+        }
+
+        private static bool IsCommandEnabled()
+        {
+            return RunArtifactManager.instance is not null
+                   && RunArtifactManager.instance.isActiveAndEnabled
+                   && RunArtifactManager.instance.IsArtifactEnabled(RoR2Content.Artifacts.commandArtifactDef);
+        }
+
+        private static bool IsSwarmEnabled()
+        {
+            return RunArtifactManager.instance is not null
+                   && RunArtifactManager.instance.isActiveAndEnabled
+                   && RunArtifactManager.instance.IsArtifactEnabled(RoR2Content.Artifacts.swarmsArtifactDef);
+        }
+
+        private int GetPlayerCount()
+        {
+            return PlayerCharacterMasterController.instances.Count(pc => pc.isConnected);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,13 +1,62 @@
 # InstanceLootPlugin
 
-This plugin is used to provide instance based loot when you're running with "Artifact of Sacrifice" and "Artifact of Command" enabled. 
+This plugin is used to provide instance based loot when you're running with "Artifact of Sacrifice" and "Artifact of Command" enabled.
 
-* Adds a console command `drop_rate <value>` to set a custom drop rate for items (0-100)
-* Adds a shortcut `F3` to pull all unpicked items to you
+## Features
 
-Contributors:
+- Ensures drop rates are appropriate for the number of players, since all drops are shared now.
+- Adds bad luck protection to prevent long stretches without item drops from kills.
+- Adds a shortcut `F3` to pull all unpicked items to you.
+- Adds a console command `drop_rate <value>` to set a custom drop rate for items (0-100).
+- Adds a console command `drop_rate_report` to view drop rate statistics for your run in the debugging window.
 
-* [tgrieger](https://github.com/tgrieger)
+## Changelog
 
+### 2.0.0
 
+#### Fixes
 
+- No longer despawns all item drops if Artifact of Command is disabled.
+- Mod will disable itself during Bulwark's Ambry to avoid a bug causing Artifacts to not be rewarded on successful clears.
+- [DropInMultiplayer] Focusing (alt-tab) the Application will fix loot being non-interactable if a player joins after a level has loaded. This issue will resolve automatically at the beginning of the next stage if no action is taken.
+- Resolve NRE log spam from F3 keybind when no items can be pulled.
+
+#### Configuration Options
+
+- Base drop rate
+- Disable player-based drop rates
+- Disable swarm drop rate modifier
+- Minimum drop rate
+- Drop rate mulitplier
+
+#### Dynamic Drop Rates
+
+There are a lot of details here, so it can be hard to understand how the game actually _feels_ with these changes.
+
+Here is what we aimed for:
+
+- Roughly 1 item per minute (this inevitably speeds up later in the game).
+- More consistent experiences with varying group sizes. (Roughly the same item rate as solo play.)
+- More consistent experiences with and without Artifact of Swarms.
+
+**Balance Changes**
+
+1. Compensate drop rate for Artifact of Swarms (the game doubles spawns, but reduces drop rates by as little as 15%).
+2. Ensures drop rates are appropriate for the number of players, since all drops are shared now.
+3. Account for additional factors used by the game when calculating drop rates.
+   - Artifact of Swarms lowers drop chances. (Lemurian w/ Swarms: 5%) vs (Lemurian w/o Swarms: 7.9%)
+   - Elites have higher drop rates than normal enemies. (Normal Lemurian: 7.9%) vs (Elite Lemurian: 19%)
+   - Some enemies have a higher base drop rate than others. (Normal Beetle: 5%) vs (Normal Scavenger: 43.2%)
+   - Some entities have a native drop rate of 0%. (Mending healing orbs, TheBackup drones, Void Infestors)
+4. Bad Luck Protection: A 4 player lobby will have a base drop rate of 1.25, so it is possible for drops to feel scarce. We prevent unlucky streaks by adding all drop chances to a pool, and increasing drop rates after it reaches 100%. Bad luck protection only kicks in if the survivor's item count is falling behind (fewer item drops than expected or low item drops per minute).
+   - Example: Survivors have killed 80 enemies with a drop rate of 1.25%, adding up to 100%.
+     - next enemy has a 1.25% drop rate, so the drop rate will be bumped to 2.5%. (cumulative chance = 101.25%)
+     - next enemy has a 3% drop rate, so the drop rate will be bumped to 7.25%. (cumulative chance = 104.25%)
+     - next enemy has a 1.25% drop rate, so the drop rate will be bumped to 6.75%. (cumulative chance = 105.5%)
+     - next enemy has a 5% drop rate, so the drop rate will be bumped to 10.5%. (cumulative chance = 110.5%)
+5. Do not scale teleporter loot drops by player count
+
+### Contributors
+
+- [tgrieger](https://github.com/tgrieger)
+- Grey

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
     "name": "InstanceBasedLoot",
-    "version_number": "1.0.0",
+    "version_number": "2.0.0",
     "website_url": "https://github.com/programit/RoR2InstanceLootPlugin",
-    "description": "Adds instance based loot when you're running with \"Artifact of Sacrifice\" and \"Artifact of Command\" enabled. Adds a console command drop_rate <value> to set a custom drop rate for items Adds a shortcut F3 to pull all unpicked items to you",
+    "description": "Adds balanced, instance-based loot when you're running with \"Artifact of Sacrifice\" and \"Artifact of Command\" enabled. Adds a shortcut F3 to pull all unpicked items to you",
     "dependencies": [
 		"bbepis-BepInExPack-5.4.2113",
 		"RiskofThunder-HookGenPatcher-1.2.3",


### PR DESCRIPTION
## Summary
Hey, awesome mod! I have been using it and made some tweaks along the way, most of them balance related.
Questions and feedback welcome! 

(Below is a copy paste from the Changelog entry in the README)

#### Fixes

- No longer despawns all item drops if Artifact of Command is disabled.
- Mod will disable itself during Bulwark's Ambry to avoid a bug causing Artifacts to not be rewarded on successful clears.
- [DropInMultiplayer] Focusing (alt-tab) the Application will fix loot being non-interactable if a player joins after a level has loaded. This issue will resolve automatically at the beginning of the next stage if no action is taken.
- Resolve NRE log spam from F3 keybind when no items can be pulled.

#### Configuration File Options

- Base drop rate
- Disable player-based drop rates
- Disable swarm drop rate modifier
- Minimum drop rate
- Drop rate mulitplier

#### Dynamic Drop Rates

There are a lot of details here, so it can be hard to understand how the game actually _feels_ with these changes.

Here is what we aimed for:

- Roughly 1 item per minute (this inevitably speeds up later in the game).
- More consistent experiences with varying group sizes. (Roughly the same item rate as solo play.)
- More consistent experiences with and without Artifact of Swarms.

**Balance Changes**

1. Compensate drop rate for Artifact of Swarms (the game doubles spawns, but reduces drop rates by as little as 15%).
2. Ensures drop rates are appropriate for the number of players, since all drops are shared now.
3. Account for additional factors used by the game when calculating drop rates.
   - Artifact of Swarms lowers drop chances. (Lemurian w/ Swarms: 5%) vs (Lemurian w/o Swarms: 7.9%)
   - Elites have higher drop rates than normal enemies. (Normal Lemurian: 7.9%) vs (Elite Lemurian: 19%)
   - Some enemies have a higher base drop rate than others. (Normal Beetle: 5%) vs (Normal Scavenger: 43.2%)
   - Some entities have a native drop rate of 0%. (Mending healing orbs, TheBackup drones, Void Infestors)
4. Bad Luck Protection: A 4 player lobby will have a base drop rate of 1.25, so it is possible for drops to feel scarce. We prevent unlucky streaks by adding all drop chances to a pool, and increasing drop rates after it reaches 100%. Bad luck protection only kicks in if the survivors item count is falling behind (fewer item drops than expected or low item drops per minute).
   - Example: Survivors have killed 80 enemies with a drop rate of 1.25%, adding up to 100%.
     - next enemy has a 1.25% drop rate, so the drop rate will be bumped to 2.5%. (cumulative chance = 101.25%)
     - next enemy has a 3% drop rate, so the drop rate will be bumped to 7.25%. (cumulative chance = 104.25%)
     - next enemy has a 1.25% drop rate, so the drop rate will be bumped to 6.75%. (cumulative chance = 105.5%)
     - next enemy has a 5% drop rate, so the drop rate will be bumped to 10.5%. (cumulative chance = 110.5%)
     
