### PR TITLE
Fix Interaction between InstanceLoot and ComandQueue plugins

### DIFF
--- a/InstanceLootPlugin/InstanceLootPlugin.cs
+++ b/InstanceLootPlugin/InstanceLootPlugin.cs
@@ -333,10 +333,7 @@ namespace InstanceLootPlugin
             if (interactableObject.name.StartsWith("CommandCube"))
             {
                 var picker = interactableObject.GetComponent<PickupPickerController>();
-                picker.panelInstance = UnityEngine.Object.Instantiate<GameObject>(picker.panelPrefab, ((MPEventSystem)EventSystem.current).localUser.cameraRigController.hud.mainContainer.transform);
-                picker.panelInstanceController = picker.panelInstance.GetComponent<PickupPickerPanel>();
-                picker.panelInstanceController.pickerController = picker;
-                picker.panelInstanceController.SetPickupOptions(picker.options);
+                picker.OnDisplayBegin(null, null, ((MPEventSystem)EventSystem.current).localUser.cameraRigController);
             }
             else
             {

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This plugin is used to provide instance based loot when you're running with "Art
 
 ## Changelog
 
+### 2.0.1
+
+- Fix compatibility with CommandQueue mod
+
 ### 2.0.0
 
 #### Fixes


### PR DESCRIPTION
Fixes #1 

Change override for AttemptInteraction to still call PickupPickerController.OnDisplayBegin(). That method is hooked by the CommandQueue plugin and if it isn't invoked the plugin does not get a change to run properly. Given that path doesn't care about local vs network object it looks safe to just invoke that method instead of executing the copy pasted innerd's we were running.

