### PR TITLE
2.1.0 - Fix compatibility after Devotion update

### DIFF
--- a/InstanceLootPlugin/InstanceLootPlugin.csproj
+++ b/InstanceLootPlugin/InstanceLootPlugin.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="R2API.Networking" Version="1.0.2" />
     <PackageReference Include="RiskOfRain2.GameLibs" Version="1.2.4-r.0" />
     <PackageReference Include="UnityEngine.Modules" Version="2019.4.26" />
-    <PackageReference Include="MMHOOK.RoR2" Version="2022.9.20">
+    <PackageReference Include="MMHOOK.RoR2" Version="2024.5.24">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This plugin is used to provide instance based loot when you're running with "Art
 - Adds a console command `drop_rate_report` to view drop rate statistics for your run in the debugging window.
 
 ## Changelog
+### 2.1.0
+
+- Fix compatibility after Devotion update
 
 ### 2.0.1
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "InstanceBasedLoot",
-    "version_number": "2.0.0",
+    "version_number": "2.0.1",
     "website_url": "https://github.com/programit/RoR2InstanceLootPlugin",
     "description": "Adds balanced, instance-based loot when you're running with \"Artifact of Sacrifice\" and \"Artifact of Command\" enabled. Adds a shortcut F3 to pull all unpicked items to you",
     "dependencies": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "InstanceBasedLoot",
-    "version_number": "2.0.1",
+    "version_number": "2.1.0",
     "website_url": "https://github.com/programit/RoR2InstanceLootPlugin",
     "description": "Adds balanced, instance-based loot when you're running with \"Artifact of Sacrifice\" and \"Artifact of Command\" enabled. Adds a shortcut F3 to pull all unpicked items to you",
     "dependencies": [


### PR DESCRIPTION
Devotion update broke the plugin due to refactoring. Logic from CommandArtifactManager was mostly lifted and shifted to PickupDropletController, so updated hooks to use the new route